### PR TITLE
fix bug with size of editable diagram name

### DIFF
--- a/src/app/editor/editor.component.scss
+++ b/src/app/editor/editor.component.scss
@@ -26,4 +26,8 @@
     display: inline-block;
     margin: 10px 0;
     font-size: 20px;
+    max-width: 100%;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
 }

--- a/src/app/editor/editor.component.ts
+++ b/src/app/editor/editor.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, HostListener } from '@angular/core';
 
 @Component({
     selector: 'de-editor',
@@ -8,6 +8,13 @@ import { Component, OnInit } from '@angular/core';
 export class EditorComponent implements OnInit {
 
     constructor() { }
+
+    @HostListener('keydown', ['$event'])
+    nameChanged($event) {
+        if ($event.keyCode === 13) {
+            $event.preventDefault();
+        }
+    }
 
     ngOnInit() {
     }


### PR DESCRIPTION
Now max displaying size of diagram name block is one row in user screen.